### PR TITLE
Modified `args.py` so that commandline arguments are read.

### DIFF
--- a/src/trans_checker/args.py
+++ b/src/trans_checker/args.py
@@ -73,5 +73,4 @@ parser.add_argument('--xavier_initialization', type=bool, default=True,
 parser.add_argument('--gpu', type=int, default=0, help='gpu device (default: 0)')
 parser.add_argument('--seed', type=int, default=543, metavar='S', help='random seed (default: 543)')
 
-args = ['--gpu', '0']
-args = parser.parse_args(args)
+args = parser.parse_args()


### PR DESCRIPTION
No commandline arguments were be read when using 
```
args = ['--gpu', '0']`
args = parser.parse_args(args)
```

`args = parser.parse_args()` allows arguments to be read.