### PR TITLE
Fix tqdm RuntimeError: cannot join thread

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 revtok==0.0.3
-tqdm==4.27
+tqdm==4.29
 torchvision==0.2.1
 mo-future>=2.20
 pyparsing==2.3.0


### PR DESCRIPTION
When training model occasionally you can receive `RuntimeError: cannot join current thread`:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/dist-packages/tqdm/_tqdm.py", line 885, in __del__
    self.close()
  File "/usr/local/lib/python3.7/dist-packages/tqdm/_tqdm.py", line 1090, in close
    self._decr_instances(self)
  File "/usr/local/lib/python3.7/dist-packages/tqdm/_tqdm.py", line 454, in _decr_instances
    cls.monitor.exit()
  File "/usr/local/lib/python3.7/dist-packages/tqdm/_monitor.py", line 52, in exit
    self.join()
  File "/usr/lib/python3.7/threading.py", line 1051, in join
    raise RuntimeError("cannot join current thread")
RuntimeError: cannot join current thread
```


This is known bug for tqdm starting from 4.22 to 4.28:
https://github.com/tqdm/tqdm/issues/613

Fix: https://github.com/tqdm/tqdm/pull/641
Even though PR for the fix is closed it is actually merged: https://github.com/tqdm/tqdm/commit/6081329a6031066744c748eb8cf89639e8a43094

Receiving `RuntimeError` means the training stops so that's critical.